### PR TITLE
Feature/listar informes curriculares

### DIFF
--- a/frontend/react-app/src/App.tsx
+++ b/frontend/react-app/src/App.tsx
@@ -11,6 +11,8 @@ import InformeCurricular from "./paginas/InformeCurricular.tsx";
 import "bootstrap/dist/css/bootstrap.min.css";
 import ReportesDisponibles from "./paginas/ReportesDisponibles.tsx";
 import EncuestasRespondidas from "./componentes/EncuestasRespondidas.tsx";
+import InformeCurricularPage from "./paginas/InformeCurricularPage.tsx";
+
 
 function App() {
   return (
@@ -44,7 +46,7 @@ function App() {
       <Route path="/departamento" element={<LayoutDepartamento />}>
         <Route index element={<InformesCurricularesDisponibles />} />
         <Route path="informes">
-          <Route path=":id" element={<InformeCurricular />} />
+          <Route path=":id" element={<InformeCurricularPage />} />
           <Route index element={<InformesCurricularesDisponibles />} />
         </Route>
       </Route>

--- a/frontend/react-app/src/App.tsx
+++ b/frontend/react-app/src/App.tsx
@@ -12,6 +12,7 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import ReportesDisponibles from "./paginas/ReportesDisponibles.tsx";
 import EncuestasRespondidas from "./componentes/EncuestasRespondidas.tsx";
 import InformeCurricularPage from "./paginas/InformeCurricularPage.tsx";
+import InformesSinteticosDisponibles from "./paginas/InformesSinteticosDisponibles.tsx";
 
 
 function App() {
@@ -49,6 +50,7 @@ function App() {
           <Route path=":id" element={<InformeCurricularPage />} />
           <Route index element={<InformesCurricularesDisponibles />} />
         </Route>
+        <Route path="informes-sinteticos" element={<InformesSinteticosDisponibles />} />
       </Route>
     </Routes>
   );

--- a/frontend/react-app/src/componentes/InformeGrupo.tsx
+++ b/frontend/react-app/src/componentes/InformeGrupo.tsx
@@ -1,0 +1,50 @@
+import Accordion from "react-bootstrap/Accordion";
+import Table from "react-bootstrap/Table";
+import { InformeItem } from "./InformeItem";
+
+type Props = {
+  titulo: string;
+  eventKey: string;
+  informes: {
+    id: number;
+    asignatura: string;
+    sede: string;
+    fechaFin: string;
+    docente: string;
+    estado: "abierto" | "cerrado";
+  }[];
+};
+
+export function InformeGrupo({ titulo, eventKey, informes }: Props) {
+  return (
+    <Accordion.Item eventKey={eventKey}>
+      <Accordion.Header>{titulo} ({informes.length})</Accordion.Header>
+      <Accordion.Body>
+        <Table striped bordered hover>
+          <thead>
+            <tr>
+              <th>Asignatura</th>
+              <th>Sede</th>
+              <th>Docente</th>
+              <th>Fecha Fin</th>
+              <th>Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            {informes.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="text-muted text-center">
+                  No hay informes en esta categoría.
+                </td>
+              </tr>
+            ) : (
+              informes.map((informe) => (
+                <InformeItem key={informe.id} {...informe} />
+              ))
+            )}
+          </tbody>
+        </Table>
+      </Accordion.Body>
+    </Accordion.Item>
+  );
+}

--- a/frontend/react-app/src/componentes/InformeItem.tsx
+++ b/frontend/react-app/src/componentes/InformeItem.tsx
@@ -1,6 +1,4 @@
 import { Link } from "react-router-dom";
-
-const API_URL = "http://localhost:8000";
 export type Props = {
   id: number;
   asignatura: string;

--- a/frontend/react-app/src/componentes/InformeItem.tsx
+++ b/frontend/react-app/src/componentes/InformeItem.tsx
@@ -1,0 +1,32 @@
+import { Link } from "react-router-dom";
+
+const API_URL = "http://localhost:8000";
+export type Props = {
+  id: number;
+  asignatura: string;
+  sede: string;
+  fechaFin: string;
+  docente: string;
+  estado: "abierto" | "cerrado";
+};
+
+export function InformeItem({ id, asignatura, sede, fechaFin, docente }: Props) {
+  return (
+    <tr>
+      <td>{asignatura}</td>
+      <td>{sede}</td>
+      <td>{docente}</td>
+      <td>{fechaFin}</td>
+      <td>
+        <Link
+          to={`/departamento/informes/${id}`}
+          className="btn btn-primary btn-sm"
+        >
+          Ver informe
+        </Link>
+      </td>
+    </tr>
+  );
+}
+export default InformeItem;
+

--- a/frontend/react-app/src/componentes/LayoutReporte.tsx
+++ b/frontend/react-app/src/componentes/LayoutReporte.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import type { Carrera } from '../types/models/Carrera';
 
 interface Props {
   asignatura: string;
   anio: number;
   docente: string;
-  carrera: string;
+  carrera: Carrera;
   children: React.ReactNode;
 }
 
@@ -13,7 +14,7 @@ const LayoutReporte: React.FC<Props> = ({ asignatura, anio, docente, carrera, ch
     <div style={{ padding: '2rem' }}>
       <div style={{ marginBottom: '1rem', background: '#f0f0f0', padding: '1rem', borderRadius: '8px' }}>
         <strong>Asignatura:</strong> {asignatura} | <strong>Año:</strong> {anio} |{' '}
-        <strong>Docente:</strong> {docente} | <strong>Carrera:</strong> {carrera}
+        <strong>Docente:</strong> {docente} | <strong>Carrera:</strong> {carrera.nombre}
       </div>
       {children}
     </div>

--- a/frontend/react-app/src/componentes/ListadoInformes.tsx
+++ b/frontend/react-app/src/componentes/ListadoInformes.tsx
@@ -1,0 +1,36 @@
+import Table from "react-bootstrap/Table";
+import { InformeItem } from "./InformeItem";
+import type { Props as InformeProps } from "./InformeItem";
+
+type Props = {
+  informes: InformeProps[];
+};
+
+export function ListadoDeInformes({ informes }: Props) {
+  return (
+    <Table className="table table-striped border mt-4">
+      <thead>
+        <tr>
+          <th>Asignatura</th>
+          <th>Sede</th>
+          <th>Docente</th>
+          <th>Fecha Fin</th>
+          <th>Acciones</th>
+        </tr>
+      </thead>
+      <tbody>
+        {informes.length === 0 ? (
+          <tr>
+            <td colSpan={5} className="text-muted text-center">
+              No hay informes disponibles.
+            </td>
+          </tr>
+        ) : (
+          informes.map((informe) => (
+            <InformeItem key={informe.id} {...informe} />
+          ))
+        )}
+      </tbody>
+    </Table>
+  );
+}

--- a/frontend/react-app/src/hook/useInformesCurriculares.ts
+++ b/frontend/react-app/src/hook/useInformesCurriculares.ts
@@ -1,20 +1,12 @@
+import type { InformeCurricular, InformeCurricularPayload } from "../types/models/InformeCurricular";
+import { useState, useCallback, useEffect } from "react";
 const API_URL = "http://localhost:8000";
 
 export function useInformesCurriculares() {
-  const crearInformeCurricular = async (payload: {
-    fecha_inicio: string;
-    fecha_fin: string;
-    estado: string;
-    sede: string;
-    ciclo_lectivo: number; // <-- ahora número
-    docente: string;
-    cant_alumnos_insc: number;
-    cant_comisiones_teoricas: number;
-    cant_comisiones_practicas: number;
-    id_informe_base: number;
-    id_asignatura: number;
-    id_reporte: number;
-  }) => {
+  const [informesCurriculares, setInformes] = useState<InformeCurricular[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  async function crearInformeCurricular(payload : InformeCurricularPayload): Promise<InformeCurricular> {
     const res = await fetch(`${API_URL}/informes-asignaturas/`, {
       method: "POST",
       headers: {
@@ -28,9 +20,40 @@ export function useInformesCurriculares() {
     }
 
     return await res.json();
-  };
+  }
+const fetchInformesCurriculares = useCallback(async () => {
+  try {
+    setLoading(true);
+    setError(null);
+    const res = await fetch(`${API_URL}/informes-asignaturas`);
+          if (!res.ok) throw new Error("No se pudo obtener la lista de reportes");
+      const data = await res.json();
+      setInformes(data);
+    } catch (err: any) {
+      console.error(err);
+      setError(err.message || "Error desconocido al cargar reportes");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const fetchInformeById = useCallback(async (id: number): Promise<InformeCurricular> => {
+    const res = await fetch(`${API_URL}/informes-asignaturas/${id}`);
+    if (!res.ok) throw new Error("No se pudo obtener el informe curricular");
+    return await res.json();
+  }, []);
+
+  useEffect(() => {
+    fetchInformesCurriculares();
+  }, [fetchInformesCurriculares]);
 
   return {
+    informesCurriculares,
+    loading,
+    error,  
     crearInformeCurricular,
+    fetchInformeById,
+
+
   };
 }

--- a/frontend/react-app/src/paginas/InformeCurricularPage.tsx
+++ b/frontend/react-app/src/paginas/InformeCurricularPage.tsx
@@ -38,6 +38,8 @@ useEffect(() => {
   if (error) return <p style={{ color: "red" }}>{error}</p>;
   if (!informe) return <p>No se encontró el informe solicitado.</p>;
 
+   console.log("Informe recibido:", informe);
+
   return (
     <div style={{ padding: "1rem" }}>
       <h1>{informe.asignatura.nombre}</h1>
@@ -49,7 +51,7 @@ useEffect(() => {
       <p><strong>Alumnos inscriptos:</strong> {informe.cant_alumnos_insc}</p>
       <p><strong>Comisiones teóricas:</strong> {informe.cant_comisiones_teoricas}</p>
       <p><strong>Comisiones prácticas:</strong> {informe.cant_comisiones_practicas}</p>
-      <p><strong>Carrera:</strong> {informe.asignatura.carrera}</p>
+      <p><strong>Carrera:</strong> {informe.asignatura.carrera.nombre}</p>
       <p><strong>Año:</strong> {informe.asignatura.año}</p>
       <p><strong>Cursado:</strong> {informe.asignatura.cursado}</p>
     </div>

--- a/frontend/react-app/src/paginas/InformeCurricularPage.tsx
+++ b/frontend/react-app/src/paginas/InformeCurricularPage.tsx
@@ -1,0 +1,57 @@
+import { useParams } from "react-router-dom";
+import { useInformesCurriculares } from "../hook/useInformesCurriculares";
+import { useEffect, useState } from "react";
+import type { InformeCurricular } from "../types/models/InformeCurricular";
+
+export default function InformeDetallePage() {
+  const { id } = useParams();
+  const { fetchInformeById } = useInformesCurriculares();
+
+  const [informe, setInforme] = useState<InformeCurricular | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+useEffect(() => {
+  console.log("ID recibido desde URL:", id);
+
+  if (!id) {
+    setError("ID inválido en la URL.");
+    setLoading(false);
+    return;
+  }
+
+  fetchInformeById(Number(id))
+    .then((data) => {
+      console.log("Informe recibido:", data);
+      setInforme(data);
+      setLoading(false);
+    })
+    .catch((err) => {
+      console.error("Error al obtener informe:", err);
+      setError("No se pudo cargar el informe.");
+      setLoading(false);
+    });
+}, [id, fetchInformeById]);
+
+
+  if (loading) return <p>Cargando informe...</p>;
+  if (error) return <p style={{ color: "red" }}>{error}</p>;
+  if (!informe) return <p>No se encontró el informe solicitado.</p>;
+
+  return (
+    <div style={{ padding: "1rem" }}>
+      <h1>{informe.asignatura.nombre}</h1>
+      <p><strong>Docente:</strong> {informe.docente}</p>
+      <p><strong>Ciclo lectivo:</strong> {informe.ciclo_lectivo}</p>
+      <p><strong>Periodo:</strong> {informe.fecha_inicio} al {informe.fecha_fin}</p>
+      <p><strong>Sede:</strong> {informe.sede}</p>
+      <p><strong>Estado:</strong> {informe.estado}</p>
+      <p><strong>Alumnos inscriptos:</strong> {informe.cant_alumnos_insc}</p>
+      <p><strong>Comisiones teóricas:</strong> {informe.cant_comisiones_teoricas}</p>
+      <p><strong>Comisiones prácticas:</strong> {informe.cant_comisiones_practicas}</p>
+      <p><strong>Carrera:</strong> {informe.asignatura.carrera}</p>
+      <p><strong>Año:</strong> {informe.asignatura.año}</p>
+      <p><strong>Cursado:</strong> {informe.asignatura.cursado}</p>
+    </div>
+  );
+}

--- a/frontend/react-app/src/paginas/InformesCurricularesDisponibles.tsx
+++ b/frontend/react-app/src/paginas/InformesCurricularesDisponibles.tsx
@@ -29,7 +29,7 @@ const mapInforme = (i: any) => {
   return (
     
     <div className="container mt-4">
-      <h2 className="mb-4">Gestión de Informes</h2>
+      <h2 className="mb-4">Gestión de Informes Curriculares</h2>
       <Accordion defaultActiveKey={null} flush>
         <InformeGrupo titulo="INFORMES ABIERTOS" eventKey="0" informes={abiertos.map(mapInforme)} />
         <InformeGrupo titulo="INFORMES CERRADOS" eventKey="1" informes={cerrados.map(mapInforme)} />

--- a/frontend/react-app/src/paginas/InformesCurricularesDisponibles.tsx
+++ b/frontend/react-app/src/paginas/InformesCurricularesDisponibles.tsx
@@ -1,6 +1,7 @@
 import { useInformesCurriculares } from "../hook/useInformesCurriculares";
-import Table from "react-bootstrap/Table";
-import { Link } from "react-router-dom";
+import Accordion from "react-bootstrap/Accordion";
+import { InformeGrupo } from "../componentes/InformeGrupo";
+
 
 export default function InformesCurricularesDisponibles() {
   const { informesCurriculares, loading, error } = useInformesCurriculares();
@@ -8,42 +9,31 @@ export default function InformesCurricularesDisponibles() {
   if (loading) return <p>Cargando informes...</p>;
   if (error) return <p>Error: {error}</p>;
 
-  const Cerrados = informesCurriculares.filter((informe) => informe.estado === "cerrado");
+  const cerrados = informesCurriculares.filter((informe) => informe.estado === "cerrado");
+  const abiertos = informesCurriculares.filter((informe) => informe.estado === "abierto");
+
+const mapInforme = (i: any) => {
+  console.log("Informe recibido:", i); // 👈 Esto te muestra el objeto completo en consola
+
+  return {
+    id: i.id,
+    asignatura: i.asignatura.nombre, // si es un objeto
+    sede: i.sede,
+    fechaFin: i.fecha_fin,
+    docente: i.docente,       // si es un objeto
+    estado: i.estado,
+  };
+};
+
 
   return (
-    <div className="container mt-3 p-4  border">
-      <h2 className="m-3">Informes Disponibles</h2>
-      <Table className="table table-striped border mt-5">
-        <thead>
-          <tr className="border">
-            <th>Cod. Asignatura</th>
-            <th>Docente</th>
-            <th>Acciones</th>
-          </tr>
-        </thead>
-        <tbody>
-          {Cerrados.length === 0 ? (
-            <tr>
-              <td colSpan={2}>No hay informes cerrados disponibles.</td>
-            </tr>
-          ) : (
-            Cerrados.map((informe) => (
-              <tr key={informe.id}>
-                <td>{informe.cod_act_curricular}</td>
-                <td>{informe.doc_responsable}</td>
-                <td>
-                  <Link
-                    to={`/departamento/informes/${informe.id}`}
-                    className="btn btn-primary m-2 sm"
-                  >
-                  Ir a informe
-                  </Link>
-                </td>
-              </tr>
-            ))
-          )}
-        </tbody>
-      </Table>
+    
+    <div className="container mt-4">
+      <h2 className="mb-4">Gestión de Informes</h2>
+      <Accordion defaultActiveKey={null} flush>
+        <InformeGrupo titulo="INFORMES ABIERTOS" eventKey="0" informes={abiertos.map(mapInforme)} />
+        <InformeGrupo titulo="INFORMES CERRADOS" eventKey="1" informes={cerrados.map(mapInforme)} />
+      </Accordion>
     </div>
   );
 }

--- a/frontend/react-app/src/paginas/InformesCurricularesDisponibles.tsx
+++ b/frontend/react-app/src/paginas/InformesCurricularesDisponibles.tsx
@@ -13,7 +13,7 @@ export default function InformesCurricularesDisponibles() {
   const abiertos = informesCurriculares.filter((informe) => informe.estado === "abierto");
 
 const mapInforme = (i: any) => {
-  console.log("Informe recibido:", i); // 👈 Esto te muestra el objeto completo en consola
+  console.log("Informe recibido:", i); //  Esto te muestra el objeto completo en consola
 
   return {
     id: i.id,

--- a/frontend/react-app/src/paginas/InformesSinteticosDisponibles.tsx
+++ b/frontend/react-app/src/paginas/InformesSinteticosDisponibles.tsx
@@ -1,0 +1,4 @@
+
+
+export default () => <h2>Gestión de Informes Sintéticos</h2>;
+

--- a/frontend/react-app/src/paginas/ReportesDisponibles.tsx
+++ b/frontend/react-app/src/paginas/ReportesDisponibles.tsx
@@ -36,7 +36,7 @@ export default function ReportesDisponibles() {
                   <td>{asignatura.año}</td>
                   <td>{asignatura.cursado}</td>
                   <td>{asignatura.nombre_docente}</td>
-                  <td>{asignatura.carrera}</td>
+                  <td>{asignatura.carrera.nombre}</td>
                   <td>
                     {/* Ver Reporte siempre */}
                     <Link

--- a/frontend/react-app/src/types/models/Asignatura.ts
+++ b/frontend/react-app/src/types/models/Asignatura.ts
@@ -1,10 +1,11 @@
 import type { Cursado } from "./Cursado";
- 
+import type { Carrera } from "./Carrera";
+
 export interface Asignatura {
     id: number;
     nombre: string;
     nombre_docente: string;
     año: number;
-    carrera: string;
+    carrera: Carrera;
     cursado: Cursado;
 }

--- a/frontend/react-app/src/types/models/Carrera.ts
+++ b/frontend/react-app/src/types/models/Carrera.ts
@@ -1,0 +1,6 @@
+
+export interface Carrera {
+  id: number; // 
+  nombre: string;
+  sede: string;
+}

--- a/frontend/react-app/src/types/models/InformeCurricular.ts
+++ b/frontend/react-app/src/types/models/InformeCurricular.ts
@@ -1,5 +1,6 @@
 import type { Asignatura } from "./Asignatura";
 import type { Reporte } from "./Reporte";
+
 enum EstadoInformeCurricular {
   abierto = "abierto",
   cerrado = "cerrado",

--- a/frontend/react-app/src/types/models/InformeCurricular.ts
+++ b/frontend/react-app/src/types/models/InformeCurricular.ts
@@ -27,19 +27,16 @@ export interface InformeCurricular {
 
 // Payload para crear o actualizar un Informe Curricular
 export interface InformeCurricularPayload {
-    fecha_inicio: string;
-    fecha_fin: string;
-    estado: string;
-
-    sede: string;
-    ciclo_lectivo: string;
-    docente: string;
-
-    cant_alumnos_insc: number;
-    cant_comisiones_teoricas: number;
-    cant_comisiones_practicas: number;
-
-    id_informe_base: number;
-    id_asignatura: number;
-    id_reporte: number;
+  fecha_inicio: string;
+  fecha_fin: string;
+  estado: string;
+  sede: string;
+  ciclo_lectivo: number;
+  docente: string;
+  cant_alumnos_insc: number;
+  cant_comisiones_teoricas: number;
+  cant_comisiones_practicas: number;
+  id_informe_base: number;
+  id_asignatura: number;
+  id_reporte: number;
 }

--- a/frontend/react-app/src/types/models/InformeCurricular.ts
+++ b/frontend/react-app/src/types/models/InformeCurricular.ts
@@ -1,16 +1,44 @@
+import type { Asignatura } from "./Asignatura";
+import type { Reporte } from "./Reporte";
 enum EstadoInformeCurricular {
   abierto = "abierto",
   cerrado = "cerrado",
 }
 
+
+// Modelo de Informe Curricular para leer o listar un informe curricular
 export interface InformeCurricular {
-  id: number;
+  id: number; // 
+  sede: string; 
+  ciclo_lectivo: number;
+  docente: string;
+  cant_alumnos_insc: number;
+  cant_comisiones_teoricas: number;
+  cant_comisiones_practicas: number;
+  fecha_inicio: string; 
+  fecha_fin: string;   
   estado: EstadoInformeCurricular;
-  sede: string;
-  ciclo_lectivo: string;
-  cod_act_curricular: string;
-  doc_responsable: string;
-  cant_alu_inscriptos: number;
-  cant_com_teoricas: number;
-  cant_com_practicas: number;
+  id_informe_base: number;
+  asignatura: Asignatura;
+  reporte: Reporte;
+}
+
+
+// Payload para crear o actualizar un Informe Curricular
+export interface InformeCurricularPayload {
+    fecha_inicio: string;
+    fecha_fin: string;
+    estado: string;
+
+    sede: string;
+    ciclo_lectivo: string;
+    docente: string;
+
+    cant_alumnos_insc: number;
+    cant_comisiones_teoricas: number;
+    cant_comisiones_practicas: number;
+
+    id_informe_base: number;
+    id_asignatura: number;
+    id_reporte: number;
 }


### PR DESCRIPTION
agregue informeGrupo, InformeItem, listadoInformes para el desplegable del listado(ver si cambiar eso para mantener la misma estructura en toda la pagina)
agrege la pagina informeCurricularesDisponibles, e hice la logica para separar los abiertos y cerrados
agregue informeCurricularPage, que solo muestra el informe seleccionado y sus atributos(luego hay q modificar el front)
lo mismo hice en la Pagina InformesSinteticosDisponibles, solo muestra el titulo.
modifique el useInformesCurriculares, agregue un fetchInformeByID, y ademas saque el type InformeCurricular que estaba definido ahi mismo, y cree uno en type/models, para que sea mas prolijo, como veran hay 2 models definidos dentro del mismo, uno InformeCurricularPayload y otro InformeCurricular, el payload es para crear o actualizar, y el otro es para listar o leer un informe, esto para que se haga mas sencillo al momento de manipularlo, pero consumen el mismo objeto, solo uno tiene definido, en sus atributos, el Id de sus relationship, y el otro tiene definido directamente el objeto.

tambien arregle unos bugs del front que se produjeron al agregar el recurso "Carrera". 